### PR TITLE
fixed linting error

### DIFF
--- a/lib/sdk/fileUtils.js
+++ b/lib/sdk/fileUtils.js
@@ -5,7 +5,7 @@ class FileUtils {
   }
   generateFilePath (prefix, extension) {
     return prefix + new Date().toISOString()
-            .replace(/[-|:|Z|\.]/gi, '')
+            .replace(/[-|:|Z|.]/gi, '')
             .replace(/T/gi, '-') + '.' + extension
   }
 }


### PR DESCRIPTION
On running npm install I receved the following error:
```
standard: Use JavaScript Standard Style (http://standardjs.com)
patata/lib/sdk/fileUtils.js:8:30: Unnecessary escape character: \..
npm ERR! Test failed.  See above for more details.
```
This fixes that lint error